### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linguist.yml
+++ b/.github/workflows/linguist.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - "**/*"
   pull_request:
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/linguist/security/code-scanning/4](https://github.com/cooljeanius/linguist/security/code-scanning/4)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (including `test`) unless overridden. The minimal and appropriate setting here is:

- `contents: read`

This aligns with the job’s apparent needs (`actions/checkout` and local commands). No other functionality changes are needed.

Edit only `.github/workflows/linguist.yml`, inserting the permissions block after the trigger section (`on:` …) and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
